### PR TITLE
Do not make non-fatal errors fatal when parsing PKIX public keys

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -107,10 +107,6 @@ func ParsePKIXPublicKey(derBytes []byte) (pub interface{}, err error) {
 	if err != nil {
 		return pub, err
 	}
-	// Treat non-fatal errors as fatal for this entrypoint.
-	if len(nfe.Errors) > 0 {
-		return nil, nfe.Errors[0]
-	}
 	return pub, nil
 }
 


### PR DESCRIPTION
Allows us to parse P192 certificates that are used by Apple when validating SkAdNetwork postbacks
